### PR TITLE
feat: move league ID to environment variable SLEEPER_LEAGUE_ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is the Token Bowl MCP server - a Model Context Protocol server for the Token Bowl fantasy football league. Built with FastMCP and the Sleeper Fantasy Sports API, it's hardcoded for league ID `1266471057523490816` and provides 20 tools to interact with fantasy football data.
+This is the Token Bowl MCP server - a Model Context Protocol server for fantasy football leagues using the Sleeper Fantasy Sports API. Built with FastMCP, it defaults to the Token Bowl league (ID: `1266471057523490816`) but can be configured for any league via the `SLEEPER_LEAGUE_ID` environment variable. Provides 20 tools to interact with fantasy football data.
 
 **Context**: This is part of the larger `tokenbowl` system - an LLM-powered fantasy football league management system. 
 
@@ -97,7 +97,7 @@ The project is configured for Render deployment via `render.yaml`. When pushing 
 1. **sleeper_mcp.py**: Single-file MCP server implementation (20 tools)
    - Uses FastMCP framework for tool definitions
    - All tools are async functions decorated with `@mcp.tool()`
-   - Hardcoded `LEAGUE_ID = "1266471057523490816"`
+   - `LEAGUE_ID` from environment variable `SLEEPER_LEAGUE_ID` (default: `1266471057523490816`)
    - Base API URL: `https://api.sleeper.app/v1`
    - Environment-aware transport detection
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A high-performance Model Context Protocol (MCP) server for the Token Bowl fantas
 - Python 3.11 or higher
 - [uv](https://github.com/astral-sh/uv) package manager
 - Redis (for caching - optional for local development)
-- Token Bowl league access (League ID: `1266471057523490816`)
+- Sleeper Fantasy Football league access
 
 ## 🚀 Quick Start
 
@@ -113,6 +113,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `SLEEPER_LEAGUE_ID` | Sleeper league ID to use | `1266471057523490816` (Token Bowl) |
 | `REDIS_URL` | Redis connection URL | `redis://localhost:6379` |
 | `PORT` | HTTP server port (Render) | `8000` |
 | `RENDER` | Deployment flag | `false` |
@@ -292,6 +293,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 
-**Note**: This server is currently hardcoded for league ID `1266471057523490816` (Token Bowl). To use with your own league, modify the `LEAGUE_ID` constant in `sleeper_mcp.py`.
+**Note**: By default, this server uses the Token Bowl league (ID: `1266471057523490816`). To use with your own league, set the `SLEEPER_LEAGUE_ID` environment variable to your league's ID.
 
 Built with ❤️ for the fantasy football community

--- a/render.yaml
+++ b/render.yaml
@@ -9,5 +9,7 @@ services:
         value: "true"
       - key: PYTHON_VERSION
         value: "3.13"
+      - key: SLEEPER_LEAGUE_ID
+        value: "1266471057523490816"
     autoDeploy: true
     healthCheckPath: /health

--- a/scratchpad-issue-12-league-id-env-var.md
+++ b/scratchpad-issue-12-league-id-env-var.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Move League ID to Environment Variable
+**Issue #12**: https://github.com/GregBaugues/sleeper-mcp/issues/12
+
+## Problem Statement
+The league ID `1266471057523490816` is currently hardcoded in the codebase. We need to move it to an environment variable named `SLEEPER_LEAGUE_ID` for better configurability.
+
+## Files Affected
+Based on the codebase search, the following files need to be updated:
+
+### Core Implementation
+1. **sleeper_mcp.py**: 
+   - Line 28: `LEAGUE_ID = "1266471057523490816"`
+   - Line 41: Comment mentioning hardcoded league ID
+
+### Documentation
+2. **README.md**: 
+   - Line 26: Mentions league ID in requirements
+   - Line 295: Note about hardcoded league ID
+
+3. **CLAUDE.md**: 
+   - Line 7: Mentions hardcoded league ID
+   - Line 100: Mentions hardcoded LEAGUE_ID constant
+
+### Testing
+4. **tests/test_integration.py**: 
+   - Line 29: Assertion checking for hardcoded league ID
+
+5. **tests/test_sleeper_mcp.py**: 
+   - Line 14: Mock data with league ID
+   - Line 85: Test assertion with hardcoded ID
+   - Line 244: Mock draft data with league ID
+   - Line 262: Test assertion with league ID
+
+6. **tests/conftest.py**: 
+   - Line 48: Returns hardcoded league ID
+
+### Deployment
+7. **render.yaml**: 
+   - Need to add SLEEPER_LEAGUE_ID environment variable
+
+## Implementation Steps
+
+### Step 1: Update sleeper_mcp.py
+- Import os module
+- Replace hardcoded LEAGUE_ID with environment variable
+- Add fallback to current league ID for backward compatibility
+- Update docstrings
+
+### Step 2: Update tests
+- Modify tests to use environment variable
+- Keep test league ID as a constant in conftest.py
+- Update test assertions to be environment-aware
+
+### Step 3: Update documentation
+- README.md: Add SLEEPER_LEAGUE_ID to environment variables section
+- CLAUDE.md: Update references to reflect environment variable usage
+
+### Step 4: Update deployment configuration
+- render.yaml: Add SLEEPER_LEAGUE_ID to environment variables
+
+### Step 5: Testing
+- Test locally with environment variable set
+- Test without environment variable (fallback behavior)
+- Run full test suite
+
+## Environment Variable Design
+```python
+# sleeper_mcp.py
+import os
+
+# Get league ID from environment variable with fallback to Token Bowl
+LEAGUE_ID = os.environ.get("SLEEPER_LEAGUE_ID", "1266471057523490816")
+```
+
+## Backward Compatibility
+- Default to Token Bowl league ID if environment variable is not set
+- This ensures existing deployments continue to work without configuration changes
+
+## Testing Strategy
+1. Set SLEEPER_LEAGUE_ID environment variable in test environment
+2. Verify all existing tests pass
+3. Test with different league IDs
+4. Test fallback behavior when env var is not set

--- a/sleeper_mcp.py
+++ b/sleeper_mcp.py
@@ -24,8 +24,8 @@ mcp = FastMCP("tokenbowl-mcp")
 # Base URL for Sleeper API
 BASE_URL = "https://api.sleeper.app/v1"
 
-# Hardcoded league ID
-LEAGUE_ID = "1266471057523490816"
+# Get league ID from environment variable with fallback to Token Bowl
+LEAGUE_ID = os.environ.get("SLEEPER_LEAGUE_ID", "1266471057523490816")
 
 
 @mcp.tool()
@@ -38,7 +38,7 @@ async def get_league_info() -> Dict[str, Any]:
     - Scoring settings and rules
     - Playoff configuration and schedule
     - Draft settings and keeper rules
-    - League ID: 1266471057523490816 (hardcoded)
+    - League ID: Configured via SLEEPER_LEAGUE_ID env var (default: 1266471057523490816)
 
     Returns:
         Dict containing all league configuration and settings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,8 +44,8 @@ def mock_mcp_server():
 
 @pytest.fixture
 def league_id():
-    """Test league ID."""
-    return "1266471057523490816"
+    """Test league ID - uses SLEEPER_LEAGUE_ID env var if set, otherwise default."""
+    return os.environ.get("SLEEPER_LEAGUE_ID", "1266471057523490816")
 
 
 @pytest.fixture

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,7 +26,9 @@ class TestMCPServer:
         """Test that constants are properly defined."""
         import sleeper_mcp
 
-        assert sleeper_mcp.LEAGUE_ID == "1266471057523490816"
+        # LEAGUE_ID should be either from env var or default
+        expected_league_id = os.environ.get("SLEEPER_LEAGUE_ID", "1266471057523490816")
+        assert sleeper_mcp.LEAGUE_ID == expected_league_id
         assert sleeper_mcp.BASE_URL == "https://api.sleeper.app/v1"
 
     def test_mcp_tools_defined(self):

--- a/tests/test_sleeper_mcp.py
+++ b/tests/test_sleeper_mcp.py
@@ -11,7 +11,7 @@ import sleeper_mcp
 
 # Test data
 MOCK_LEAGUE_DATA = {
-    "league_id": "1266471057523490816",
+    "league_id": os.environ.get("SLEEPER_LEAGUE_ID", "1266471057523490816"),
     "name": "Token Bowl",
     "season": "2024",
     "sport": "nfl",
@@ -82,7 +82,8 @@ class TestLeagueTools:
         result = await sleeper_mcp.get_league_info.fn()
 
         assert "league_id" in result
-        assert result["league_id"] == "1266471057523490816"
+        expected_league_id = os.environ.get("SLEEPER_LEAGUE_ID", "1266471057523490816")
+        assert result["league_id"] == expected_league_id
         assert "name" in result
         assert "season" in result
         assert "sport" in result
@@ -241,7 +242,7 @@ class TestDraftTools:
         """Test getting draft information with mocked response."""
         mock_draft = {
             "draft_id": "987654321",
-            "league_id": "1266471057523490816",
+            "league_id": os.environ.get("SLEEPER_LEAGUE_ID", "1266471057523490816"),
             "status": "complete",
             "type": "snake",
             "settings": {"rounds": 15, "teams": 12},
@@ -259,7 +260,10 @@ class TestDraftTools:
             result = await sleeper_mcp.get_draft.fn(draft_id="987654321")
 
             assert result["draft_id"] == "987654321"
-            assert result["league_id"] == "1266471057523490816"
+            expected_league_id = os.environ.get(
+                "SLEEPER_LEAGUE_ID", "1266471057523490816"
+            )
+            assert result["league_id"] == expected_league_id
             assert result["type"] == "snake"
 
 


### PR DESCRIPTION
## Summary
- Moved hardcoded league ID to environment variable `SLEEPER_LEAGUE_ID`
- Maintains backward compatibility with Token Bowl league as default
- Updates documentation and deployment configuration

## Changes
- Added `SLEEPER_LEAGUE_ID` environment variable support in `sleeper_mcp.py`
- Updated all tests to use environment variable with fallback
- Updated README and CLAUDE.md documentation
- Added environment variable to `render.yaml` deployment config
- Formatted code with ruff formatter

## Test Plan
- [x] Verified default league ID loads correctly without env var
- [x] Verified custom league ID loads when env var is set
- [x] All integration tests pass
- [x] All unit tests pass
- [x] Code formatted and linted with ruff

Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)