### PR TITLE
Fix: Format Fantasy Nerds projection points to 2 decimal places

### DIFF
--- a/sleeper_mcp.py
+++ b/sleeper_mcp.py
@@ -212,9 +212,13 @@ async def get_roster(roster_id: int) -> Dict[str, Any]:
 
                     # Add weekly projection
                     if "projection_week1" in ffnerd and ffnerd["projection_week1"]:
-                        player_info["projected_points"] = ffnerd[
-                            "projection_week1"
-                        ].get("projected_points")
+                        proj_pts = ffnerd["projection_week1"].get("projected_points")
+                        # Convert string to float format with 2 decimal places
+                        if proj_pts:
+                            try:
+                                player_info["projected_points"] = f"{float(proj_pts):.2f}"
+                            except (ValueError, TypeError):
+                                pass  # Skip if conversion fails
 
             # Categorize player by roster position
             if player_id in reserve_ids:


### PR DESCRIPTION
## Summary
- Formats Fantasy Nerds projection points to always show 2 decimal places (e.g., "21.10" instead of "21.1")
- Adds error handling for invalid projection values
- Ensures consistent display format across all players in the get_roster tool

## Context
The get_roster tool was correctly fetching Fantasy Nerds projections from the unified cache, but the projection points were displayed as raw strings without consistent formatting. This made the output look inconsistent between players.

## Changes
- Modified the projection extraction logic in `get_roster()` to format points to 2 decimal places
- Added try/except block to handle any ValueError or TypeError when converting projection strings

## Test Results
Tested locally with roster ID 2 - all 9 non-defense players now show properly formatted projections:
- Josh Allen: 21.10 pts
- Jahmyr Gibbs: 18.40 pts
- James Cook: 14.80 pts
- etc.

🤖 Generated with [Claude Code](https://claude.ai/code)