### PR TITLE
Fix get_roster and cache: include all players, fix name matching

### DIFF
--- a/build_cache.py
+++ b/build_cache.py
@@ -48,7 +48,8 @@ def fetch_fantasy_nerds_data() -> tuple[Dict, Dict, List]:
     print("Fetching Fantasy Nerds weekly rankings...")
     with httpx.Client(timeout=30.0) as client:
         rankings_resp = client.get(
-            f"https://api.fantasynerds.com/v1/nfl/weekly-rankings?apikey={api_key}"
+            f"https://api.fantasynerds.com/v1/nfl/weekly-rankings?format=ppr
+&apikey={api_key}"
         )
         rankings_resp.raise_for_status()
         rankings = rankings_resp.json()


### PR DESCRIPTION
## Summary
This PR fixes two critical issues:
1. **`get_roster` function** was broken (async/await errors) and showing incorrect projections
2. **Cache was missing players** like Marvin Harrison Jr., causing artificially low projections

## Key Fixes

### 1. Fixed `get_roster` Function
- Remove `await` on sync `get_all_players()` function (was causing "dict can't be used in await expression" error)
- Fix data structure access: `data.projections` not `ffnerd_data.projection_week1`
- Add comprehensive meta information (total/starters/bench projections)
- Simplify player data extraction directly from cache

### 2. Fixed Cache Building
- **Better name matching**: Handle Jr/Sr/III suffixes (e.g., "Marvin Harrison" matches "Marvin Harrison Jr.")
- **Include ALL fantasy-relevant players**: Even those without Fantasy Nerds data
- **Increased cache size**: From 787 to 2,777 players
- Only exclude truly inactive players without injury data

### 3. Use PPR Scoring Format
- **Changed Fantasy Nerds API** to explicitly request PPR (Point Per Reception) scoring
- Previously was defaulting to standard scoring format
- Now matches Token Bowl's PPR scoring system

## Results
Bill Beliclaude's roster projections are now correct:
- **Before**: 88.1 pts for starters (missing Marvin Harrison Jr.)
- **After**: 97.2 pts for starters (127.2 total) with PPR scoring

Marvin Harrison Jr. now properly shows with 9.1 projected points for Week 1.

## Test Results
```
Meta Information:
  Record: 0-0
  Total Players: 15
  Starters Count: 10
  Total Projected Points: 127.2
  Starters Projected Points: 97.2
  Bench Projected Points: 30.0
  Injured Count: 1
```

The cache now includes all 2,777 fantasy-relevant players with PPR projections.

🤖 Generated with [Claude Code](https://claude.ai/code)