### PR TITLE
feat: Add targets to PPR stats

### DIFF
--- a/build_cache.py
+++ b/build_cache.py
@@ -83,6 +83,7 @@ def filter_ppr_relevant_stats(stats: Dict[str, Any]) -> Dict[str, Any]:
         "rush_2pt": "rushing_two_point_conversions",
         # Receiving stats (PPR)
         "rec": "receptions",
+        "rec_tgt": "targets",
         "rec_yd": "receiving_yards",
         "rec_td": "receiving_touchdowns",
         "rec_2pt": "receiving_two_point_conversions",

--- a/cache_client.py
+++ b/cache_client.py
@@ -320,6 +320,7 @@ def filter_ppr_relevant_stats(stats: Dict[str, Any]) -> Dict[str, Any]:
         "rush_td": "rushing_touchdowns",
         "rush_2pt": "rushing_two_point_conversions",
         "rec": "receptions",
+        "rec_tgt": "targets",
         "rec_yd": "receiving_yards",
         "rec_td": "receiving_touchdowns",
         "rec_2pt": "receiving_two_point_conversions",


### PR DESCRIPTION
## Summary
This PR adds the "targets" stat (rec_tgt) to the PPR stats mapping, addressing issue #45.

## Changes
- Added `"rec_tgt": "targets"` to the field_mapping in both:
  - `cache_client.py` (filter_ppr_relevant_stats function)
  - `build_cache.py` (filter_ppr_relevant_stats function)

## Why this matters
Targets indicate how many times a receiver is thrown to, which is a valuable metric for PPR (Points Per Reception) fantasy leagues. It's a good predictor of future performance as it shows player involvement in the offense.

## Testing
Tested the implementation manually and confirmed that targets are now included in player stats:

```
✓ Tyreek Hill - Targets: 6.0
✓ CeeDee Lamb - Targets: 13.0
✓ A.J. Brown - Targets: 1.0
```

The data is properly fetched from Sleeper's API (`rec_tgt` field) and mapped to a more readable `targets` field in our stats.

## Verification
- [x] Linting passes (`uv run ruff check .`)
- [x] Formatting is correct (`uv run ruff format . --check`)
- [x] Manual testing shows targets are included in stats
- [ ] Tests run (note: pre-existing test failures in mocked async tests, unrelated to this change)

Fixes #45

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>