### PR TITLE
feat: add carries to real stats

### DIFF
--- a/build_cache.py
+++ b/build_cache.py
@@ -78,6 +78,7 @@ def filter_ppr_relevant_stats(stats: Dict[str, Any]) -> Dict[str, Any]:
         "pass_int": "passing_interceptions",
         "pass_2pt": "passing_two_point_conversions",
         # Rushing stats
+        "rush_att": "carries",  # Rushing attempts
         "rush_yd": "rushing_yards",
         "rush_td": "rushing_touchdowns",
         "rush_2pt": "rushing_two_point_conversions",

--- a/cache_client.py
+++ b/cache_client.py
@@ -316,6 +316,7 @@ def filter_ppr_relevant_stats(stats: Dict[str, Any]) -> Dict[str, Any]:
         "pass_td": "passing_touchdowns",
         "pass_int": "passing_interceptions",
         "pass_2pt": "passing_two_point_conversions",
+        "rush_att": "carries",  # Rushing attempts
         "rush_yd": "rushing_yards",
         "rush_td": "rushing_touchdowns",
         "rush_2pt": "rushing_two_point_conversions",

--- a/scratchpad-issue-55-add-carries.md
+++ b/scratchpad-issue-55-add-carries.md
@@ -1,0 +1,70 @@
+# Issue #55: Add Carries to Real Stats
+
+GitHub Issue: https://github.com/GregBaugues/tokenbowl-mcp/issues/55
+
+## Problem Description
+Currently, we track targets (rec_tgt) in real stats for both:
+1. The historical stats tool (`get_player_stats_all_weeks`)
+2. The current stats in the player cache
+
+We need to also track carries (rushing attempts) to provide complete offensive stats.
+
+## Analysis
+After investigating the Sleeper API response for a running back (Saquon Barkley), I found the field name for rushing attempts is `rush_att`.
+
+Example from Sleeper API:
+```json
+{
+  "rush_att": 18.0,  // <-- This is carries/rushing attempts
+  "rush_yd": 60.0,
+  "rush_td": 1.0,
+  "rec_tgt": 5.0,    // <-- This is targets (already included)
+  "rec": 4.0,
+  "rec_yd": 24.0,
+  // ... other stats
+}
+```
+
+## Implementation Plan
+
+### Files to Modify
+1. **build_cache.py** - Add `rush_att` to the field mapping in `filter_ppr_relevant_stats()`
+2. **cache_client.py** - Add `rush_att` to the field mapping in `filter_ppr_relevant_stats()`
+
+### Specific Changes
+
+#### 1. build_cache.py (line ~83)
+Add after line 82 (rush_td):
+```python
+"rush_att": "carries",  # Rushing attempts
+```
+
+#### 2. cache_client.py (line ~320)
+Add after line 320 (rush_td):
+```python
+"rush_att": "carries",  # Rushing attempts
+```
+
+### Why This Change?
+- **Carries** are fundamental offensive stats for running backs
+- They show workload and opportunity, similar to targets for receivers
+- Essential for fantasy football analysis alongside targets
+- Both tools that show real stats will now include this important metric
+
+### Testing Approach
+1. Test with a running back (e.g., Saquon Barkley - ID 4866)
+2. Verify carries appear in:
+   - Current week stats from cache
+   - Historical stats from `get_player_stats_all_weeks`
+3. Ensure the field properly maps from `rush_att` to `carries`
+
+## Next Steps
+1. ✅ Understand the issue requirements
+2. ✅ Find the Sleeper API field name (`rush_att`)
+3. ✅ Document implementation plan
+4. Create branch `issue-55-add-carries`
+5. Update build_cache.py field mapping
+6. Update cache_client.py field mapping
+7. Test with RB player data
+8. Run linting and formatting
+9. Create PR


### PR DESCRIPTION
## Summary
- Adds carries (rushing attempts) to real stats mapping
- Maps Sleeper API field `rush_att` to `carries` in both cache files
- Complements existing `targets` field for complete offensive workload tracking

## Changes
- **build_cache.py**: Added `"rush_att": "carries"` to field mapping (line 81)
- **cache_client.py**: Added `"rush_att": "carries"` to field mapping (line 319)

## Testing
Tested with Saquon Barkley (player ID 4866) from Week 1:
- ✅ Raw API value: `rush_att: 18.0`
- ✅ Filtered value: `carries: 18.0`
- ✅ Appears alongside targets and other stats correctly

## Why This Change?
As mentioned in Issue #55, we already track targets for receiving stats. Carries are the equivalent metric for rushing workload, essential for fantasy football analysis. This provides complete offensive usage data for all players.

## Verification
```python
# Test output showing the field works:
Raw rush_att value: 18.0
✅ SUCCESS: 'carries' field found with value: 18.0

Other rushing stats in filtered data:
  carries: 18.0
  rushing_yards: 60.0
  rushing_touchdowns: 1.0

Receiving stats (for comparison):
  targets: 5.0
  receptions: 4.0
```

Fixes #55

🤖 Generated with [Claude Code](https://claude.ai/code)