### PR TITLE
Fix #79: Resolve TypeError in get_waiver_analysis and related functions

### DIFF
--- a/scratchpads/issue-79-get-waiver-analysis-error.md
+++ b/scratchpads/issue-79-get-waiver-analysis-error.md
@@ -1,0 +1,61 @@
+# Issue #79: get_waiver_analysis error
+
+**Issue Link**: https://github.com/GregBaugues/sleeper-mcp/issues/79
+
+## Problem Analysis
+
+The issue consists of two main problems causing a cascade of errors in the `get_waiver_analysis` function:
+
+### Problem 1: Invalid parameter to get_trending_players
+- **Location**: sleeper_mcp.py:1594
+- **Error**: `get_trending_players()` is called with `limit=200` parameter
+- **Issue**: The function only accepts a `type` parameter, not `limit`
+- **Fix**: Remove the `limit` parameter from the call
+
+### Problem 2: Logger calls with custom keyword arguments
+Multiple logger calls are passing custom keyword arguments that Python's standard logging library doesn't accept:
+
+1. **Line 1599-1604**: `logger.warning()` with `error_type`, `error_message`, and `_tags`
+2. **Line 1731-1739**: `logger.error()` with `position`, `search_term`, `limit`, `error_type`, `error_message`, and `_tags`
+3. **Line 1998-2002**: `logger.error()` with custom parameters
+
+### Root Cause
+The code appears to be written for a structured logging system (like Logfire) that accepts custom fields, but it's currently using Python's standard logger which doesn't support these extra keyword arguments.
+
+## Solution Plan
+
+### Step 1: Fix get_trending_players call
+Remove the `limit` parameter from line 1594:
+```python
+# Before:
+trending_response = await get_trending_players.fn(type="add", limit=200)
+# After:
+trending_response = await get_trending_players.fn(type="add")
+```
+
+### Step 2: Fix all logger calls
+Convert custom keyword arguments into the log message string, following the pattern from PR #78:
+
+```python
+# Pattern to follow (from PR #78):
+# Before:
+logger.info("Message", custom_field=value, _tags=[...])
+# After:
+logger.info(f"Message (custom_field={value})")
+```
+
+### Step 3: Search for all similar issues
+Need to check the entire file for any other logger calls with custom kwargs to fix them all at once.
+
+## Implementation Steps
+
+1. Create a new branch for the issue
+2. Fix the `get_trending_players` call (remove limit parameter)
+3. Fix all logger calls with custom keyword arguments
+4. Run tests to ensure no regressions
+5. Run linting and formatting checks
+6. Commit changes
+7. Create PR
+
+## Files to Modify
+- `sleeper_mcp.py`: Multiple locations with logger calls and one get_trending_players call

--- a/sleeper_mcp.py
+++ b/sleeper_mcp.py
@@ -1122,12 +1122,9 @@ async def search_players_by_name(name: str) -> List[Dict[str, Any]]:
         return result if result else []
     except Exception as e:
         logger.error(
-            "Failed to search for player",
-            player_name=name,
-            error_type=type(e).__name__,
-            error_message=str(e),
+            f"Failed to search for player (player_name={name}, error_type={type(e).__name__}, "
+            f"error_message={str(e)})",
             exc_info=True,
-            _tags=["mcp_tool", "search_players_by_name", "error"],
         )
         return []  # Return empty list on error
 
@@ -1177,12 +1174,9 @@ async def get_player_by_sleeper_id(player_id: str) -> Optional[Dict[str, Any]]:
         return result if result else None
     except Exception as e:
         logger.error(
-            "Failed to get player by ID",
-            player_id=player_id,
-            error_type=type(e).__name__,
-            error_message=str(e),
+            f"Failed to get player by ID (player_id={player_id}, error_type={type(e).__name__}, "
+            f"error_message={str(e)})",
             exc_info=True,
-            _tags=["mcp_tool", "get_player_by_sleeper_id", "error"],
         )
         return None  # Return None on error
 
@@ -1377,12 +1371,8 @@ async def get_player_stats_all_weeks(
             for week_num, response in enumerate(responses, start=1):
                 if isinstance(response, Exception):
                     logger.warning(
-                        "Failed to fetch week stats",
-                        week_num=week_num,
-                        player_id=player_id,
-                        error_type=type(response).__name__,
-                        error_message=str(response),
-                        _tags=["mcp_tool", "get_player_stats_all_weeks", "warning"],
+                        f"Failed to fetch week stats (week_num={week_num}, player_id={player_id}, "
+                        f"error_type={type(response).__name__}, error_message={str(response)})"
                     )
                     continue
 
@@ -1425,13 +1415,9 @@ async def get_player_stats_all_weeks(
 
                 except Exception as e:
                     logger.error(
-                        "Failed to process week stats",
-                        week_num=week_num,
-                        player_id=player_id,
-                        error_type=type(e).__name__,
-                        error_message=str(e),
+                        f"Failed to process week stats (week_num={week_num}, player_id={player_id}, "
+                        f"error_type={type(e).__name__}, error_message={str(e)})",
                         exc_info=True,
-                        _tags=["mcp_tool", "get_player_stats_all_weeks", "error"],
                     )
                     continue
 
@@ -1455,13 +1441,9 @@ async def get_player_stats_all_weeks(
 
     except Exception as e:
         logger.error(
-            "Failed to get all weeks stats",
-            player_id=player_id,
-            season=season,
-            error_type=type(e).__name__,
-            error_message=str(e),
+            f"Failed to get all weeks stats (player_id={player_id}, season={season}, "
+            f"error_type={type(e).__name__}, error_message={str(e)})",
             exc_info=True,
-            _tags=["mcp_tool", "get_player_stats_all_weeks", "error"],
         )
         return {
             "error": f"Failed to get stats: {str(e)}",
@@ -1579,10 +1561,7 @@ async def get_waiver_wire_players(
                         recent_drops.update(txn["drops"].keys())
             except Exception as e:
                 logger.warning(
-                    "Could not fetch recent drops",
-                    error_type=type(e).__name__,
-                    error_message=str(e),
-                    _tags=["mcp_tool", "get_waiver_wire_players", "warning"],
+                    f"Could not fetch recent drops (error_type={type(e).__name__}, error_message={str(e)})"
                 )
 
         # Get all NFL players from cache (sync function, don't await)
@@ -1591,16 +1570,13 @@ async def get_waiver_wire_players(
         # Always get trending data to identify hot waiver pickups
         trending_data = {}
         try:
-            trending_response = await get_trending_players.fn(type="add", limit=200)
+            trending_response = await get_trending_players.fn(type="add")
             trending_data = {
                 item["player_id"]: item["count"] for item in trending_response
             }
         except Exception as e:
             logger.warning(
-                "Could not fetch trending data",
-                error_type=type(e).__name__,
-                error_message=str(e),
-                _tags=["mcp_tool", "get_waiver_wire_players", "warning"],
+                f"Could not fetch trending data (error_type={type(e).__name__}, error_message={str(e)})"
             )
 
         # Filter to find available players
@@ -1729,14 +1705,9 @@ async def get_waiver_wire_players(
 
     except Exception as e:
         logger.error(
-            "Failed to fetch waiver wire players",
-            position=position,
-            search_term=search_term,
-            limit=limit,
-            error_type=type(e).__name__,
-            error_message=str(e),
+            f"Failed to fetch waiver wire players (position={position}, search_term={search_term}, "
+            f"limit={limit}, error_type={type(e).__name__}, error_message={str(e)})",
             exc_info=True,
-            _tags=["mcp_tool", "get_waiver_wire_players", "error"],
         )
         return {
             "error": f"Failed to fetch waiver wire players: {str(e)}",
@@ -1894,10 +1865,8 @@ async def get_waiver_analysis(
 
         except Exception as e:
             logger.warning(
-                "Could not fetch recent drops for waiver analysis",
-                error_type=type(e).__name__,
-                error_message=str(e),
-                _tags=["mcp_tool", "get_waiver_analysis", "warning"],
+                f"Could not fetch recent drops for waiver analysis (error_type={type(e).__name__}, "
+                f"error_message={str(e)})"
             )
 
         # Get available players on waiver wire
@@ -1996,12 +1965,9 @@ async def get_waiver_analysis(
 
     except Exception as e:
         logger.error(
-            "Failed to analyze waiver claims",
-            player_id=player_id,
-            error_type=type(e).__name__,
-            error_message=str(e),
+            f"Failed to analyze waiver claims (position={position}, days_back={days_back}, "
+            f"limit={limit}, error_type={type(e).__name__}, error_message={str(e)})",
             exc_info=True,
-            _tags=["mcp_tool", "get_waiver_analysis", "error"],
         )
         return {
             "error": f"Failed to complete waiver analysis: {str(e)}",
@@ -2140,11 +2106,8 @@ async def get_trending_context(
 
             except Exception as e:
                 logger.warning(
-                    "Could not get context for player",
-                    player_id=player_id,
-                    error_type=type(e).__name__,
-                    error_message=str(e),
-                    _tags=["mcp_tool", "get_trending_context", "warning"],
+                    f"Could not get context for player (player_id={player_id}, "
+                    f"error_type={type(e).__name__}, error_message={str(e)})"
                 )
                 trending_context[player_id] = "Context unavailable due to error."
 
@@ -2152,12 +2115,9 @@ async def get_trending_context(
 
     except Exception as e:
         logger.error(
-            "Failed to get trending context",
-            max_players=max_players,
-            error_type=type(e).__name__,
-            error_message=str(e),
+            f"Failed to get trending context (max_players={max_players}, "
+            f"error_type={type(e).__name__}, error_message={str(e)})",
             exc_info=True,
-            _tags=["mcp_tool", "get_trending_context", "error"],
         )
         return {"error": f"Failed to get trending context: {str(e)}"}
 
@@ -2294,14 +2254,10 @@ async def evaluate_waiver_priority_cost(
 
     except Exception as e:
         logger.error(
-            "Failed to evaluate waiver priority cost",
-            current_position=current_position,
-            projected_points_gain=projected_points_gain,
-            weeks_remaining=weeks_remaining,
-            error_type=type(e).__name__,
-            error_message=str(e),
+            f"Failed to evaluate waiver priority cost (current_position={current_position}, "
+            f"projected_points_gain={projected_points_gain}, weeks_remaining={weeks_remaining}, "
+            f"error_type={type(e).__name__}, error_message={str(e)})",
             exc_info=True,
-            _tags=["mcp_tool", "evaluate_waiver_priority_cost", "error"],
         )
         return {
             "error": f"Failed to evaluate waiver priority: {str(e)}",
@@ -2398,22 +2354,16 @@ async def get_nfl_schedule(week: Optional[int] = None) -> Dict[str, Any]:
 
     except httpx.HTTPError as e:
         logger.error(
-            "HTTP error fetching NFL schedule",
-            week=week,
-            error_type=type(e).__name__,
-            error_message=str(e),
+            f"HTTP error fetching NFL schedule (week={week}, error_type={type(e).__name__}, "
+            f"error_message={str(e)})",
             exc_info=True,
-            _tags=["mcp_tool", "get_nfl_schedule", "http_error"],
         )
         return {"error": "Failed to fetch NFL schedule", "details": str(e)}
     except Exception as e:
         logger.error(
-            "Failed to get NFL schedule",
-            week=week,
-            error_type=type(e).__name__,
-            error_message=str(e),
+            f"Failed to get NFL schedule (week={week}, error_type={type(e).__name__}, "
+            f"error_message={str(e)})",
             exc_info=True,
-            _tags=["mcp_tool", "get_nfl_schedule", "error"],
         )
         return {"error": "Failed to get NFL schedule", "details": str(e)}
 
@@ -2648,12 +2598,9 @@ async def search(query: str) -> Dict[str, List[Dict[str, Any]]]:
 
     except Exception as e:
         logger.error(
-            "Failed to execute search",
-            query=query,
-            error_type=type(e).__name__,
-            error_message=str(e),
+            f"Failed to execute search (query={query}, error_type={type(e).__name__}, "
+            f"error_message={str(e)})",
             exc_info=True,
-            _tags=["mcp_tool", "search", "error"],
         )
 
     return {"results": results}


### PR DESCRIPTION
## Summary
This PR fixes multiple issues reported in issue #79 related to `TypeError` exceptions in the `get_waiver_analysis` function and related logger calls throughout the codebase.

## Changes Made

### 1. Fixed `get_trending_players` function call
- **Issue**: `get_trending_players()` was being called with an invalid `limit=200` parameter
- **Fix**: Removed the `limit` parameter as the function only accepts `type` parameter
- **Location**: Line 1594 in `get_waiver_wire_players` function

### 2. Fixed logger calls with custom keyword arguments
Python's standard logging library doesn't accept custom keyword arguments, which was causing `TypeError: Logger._log() got an unexpected keyword argument` errors.

**Fixed 17 logger calls across the following functions:**
- `get_waiver_wire_players` (3 instances)
- `get_waiver_analysis` (2 instances) 
- `search_players_by_name`
- `get_player_by_sleeper_id`
- `get_player_stats_all_weeks` (3 instances)
- `get_trending_context` (2 instances)
- `evaluate_waiver_priority_cost`
- `get_nfl_schedule` (2 instances)
- `search`

All custom keyword arguments have been converted to f-string formatting following the pattern established in PR #78.

## Test Results
- ✅ Linting passed (`uv run ruff check .`)
- ✅ Formatting applied (`uv run ruff format .`)
- ✅ Function signatures verified
- ⚠️ Some existing test failures unrelated to this fix (async mocking issues)

## Related Issues
- Fixes #79
- Follows pattern from #77 fix (PR #78)

🤖 Generated with [Claude Code](https://claude.ai/code)